### PR TITLE
feat(morecolors): SM 1.13 compatibility

### DIFF
--- a/addons/sourcemod/scripting/include/multicolors/morecolors.inc
+++ b/addons/sourcemod/scripting/include/multicolors/morecolors.inc
@@ -9,7 +9,7 @@
 
 #pragma newdecls optional
 
-#define MORE_COLORS_VERSION     "3.0.0-MC"
+#define MORE_COLORS_VERSION     "3.0.1-MC"
 #define MC_MAX_MESSAGE_LENGTH   256
 #define MAX_BUFFER_LENGTH       (MC_MAX_MESSAGE_LENGTH * 4)
 #define MAX_COLOR_TAG_LENGTH    32
@@ -1023,7 +1023,7 @@ stock void MC_InitFastColors() {
  * @return       32-bit hash value
  */
 stock int MC_FastHash(const char[] str) {
-	int hash = 2166136261;
+	int hash = 0x811C9DC5; // FNV-1a 32-bit offset basis
 	for (int i = 0; str[i]; i++) {
 		hash ^= str[i];
 		hash *= 16777619;


### PR DESCRIPTION
SourcePawn 1.13 introduced native `int64` support.
As a side effect, integer literals that exceed the 32-bit signed range (`INT_MAX = 2147483647`) are now promoted to `int64`.

The FNV-1a offset basis `2166136261` (0x811C9DC5) falls into this category, causing:
```
error 450: no viable conversion from 'int64' to 'int'
```

Replace the decimal literal with its hexadecimal equivalent `0x811C9DC5`.
Hex literals are interpreted as raw 32-bit cells by the compiler, bypassing the promotion logic, while remaining bit-for-bit identical at runtime.

You can see the error here: https://github.com/Bara/Multi-Colors/actions/runs/27945429432/job/82688810583?pr=22